### PR TITLE
Replace bukkit consumer with java consumer

### DIFF
--- a/src/main/java/net/twiistrz/banksystem/UpdateChecker.java
+++ b/src/main/java/net/twiistrz/banksystem/UpdateChecker.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Scanner;
+import java.util.function.Consumer;
 
 import org.bukkit.Bukkit;
-import org.bukkit.util.Consumer;
 
 public class UpdateChecker {
 


### PR DESCRIPTION
There are really no purpose to use the org.bukkit.util.Consumer class,
since Java 8 comes with the java.util.function.Consumer class.

Also, using the org.bukkit.util.Consumer class gave a NoClassDefFoundError
on MC 1.8, so this fixes it.